### PR TITLE
Clean up dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c022f37ee51e54714657bbc2890b5e77582d94185f45b37c4da566ebbfa9f549
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -23,13 +23,12 @@ requirements:
   run:
     - python >=3.6
     - GDAL >=3
+    - click
     - large-image-source-gdal
     - flask >=2.0.0
     - flask-caching
     - requests
     - scooby
-    - ipyleaflet
-    - folium
 
 test:
   imports:


### PR DESCRIPTION
Most people don't want ipyleaflet and folium installed -- they are rather big dependencies. This change requires users to install those themselves.

Also, I noticed click was missing


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
